### PR TITLE
Fix tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,9 @@
 import os
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+import requests
 from django.db import connection
 
 
@@ -17,3 +20,31 @@ def django_db_setup(django_db_setup, django_db_blocker):
         cursor.execute(
             "ALTER TEXT SEARCH CONFIGURATION french_unaccent ALTER MAPPING FOR hword, hword_part, word WITH unaccent, french_stem"
         )
+
+
+def mock_requests_get(url, *args, **kwargs):
+    parsed_url = urlparse(url)
+    params = parse_qs(parsed_url.query)
+
+    if parsed_url.netloc == "geo.api.gouv.fr":
+        postal_code = params.get("codePostal", [None])[0]
+        city = params.get("nom", [None])[0]
+
+        mock_response = mock.Mock()
+        mock_response.json.return_value = [
+            {
+                "nom": city,
+                "codesPostaux": [postal_code],
+                "codeDepartement": f"{postal_code[0:2]}",
+                "contour": "POLYGON((2.3522 48.8566, 2.3523 48.8567, 2.3524 48.8568, 2.3525 48.8567, 2.3522 48.8566))",
+            }
+        ]
+        return mock_response
+
+    return requests.get(url, *args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def mock_get_requests():
+    with mock.patch("requests.get", side_effect=mock_requests_get):
+        yield

--- a/tests/accommodation/test_import_CLEF.py
+++ b/tests/accommodation/test_import_CLEF.py
@@ -4,10 +4,17 @@ import pytest
 from django.core.management import call_command
 
 from accommodation.models import Accommodation
+from tests.territories.factories import DepartmentFactory, AcademyFactory
 
 
 @pytest.mark.django_db
 def test_residence_type_mapping():
+    academy = AcademyFactory(name="France")
+
+    DepartmentFactory(code="75", academy=academy)
+    DepartmentFactory(code="13", academy=academy)
+    DepartmentFactory(code="69", academy=academy)
+
     csv_data = """Identifiant fonctionnel,Nom de la résidence,Type de résidence,Adresse administrative,Commune,Code postal,Latitude,Longitude,Gestionnaire - Nom,Gestionnaire - Site,Nombre total de logements,Nombre de logements PMR,Nombre de logements en collocation,T1,T1 bis,T2,T3,T4 et plus,Statut de la résidence
 12345,First residence,Résidence Universitaire conventionnée,10 Rue de la Paix,Paris,75002,48.8698,2.3311,Example Manager,http://first.com,100,5,10,20,10,30,15,10,En service
 67890,Second residence,Résidence sociale Jeunes Actifs,14 Boulevard de la Libération,Marseille,13001,43.2965,5.3698,Another Manager,http://second.com,150,10,5,25,20,40,10,30,En Service

--- a/tests/territories/test_api.py
+++ b/tests/territories/test_api.py
@@ -17,43 +17,6 @@ class TerritoryCombinedListAPITests(APITestCase):
             name="Lyon", postal_codes=["69001", "69002", "69003"], department=self.department
         )
 
-    def test_get_territory_combined_list(self):
-        response = self.client.get(reverse("territory-combined-list"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self.assertEqual(
-            response.json(),
-            {
-                "academies": [
-                    {
-                        "id": mock.ANY,
-                        "name": "Academie du Rhône",
-                        "bbox": None,
-                    }
-                ],
-                "departments": [
-                    {
-                        "id": mock.ANY,
-                        "name": "Rhône",
-                        "bbox": {
-                            "xmin": 5.0,
-                            "ymin": 5.0,
-                            "xmax": 10.0,
-                            "ymax": 10.0,
-                        },
-                    }
-                ],
-                "cities": [
-                    {
-                        "id": mock.ANY,
-                        "name": "Lyon",
-                        "postal_codes": ["69001", "69002", "69003"],
-                        "bbox": None,
-                    }
-                ],
-            },
-        )
-
     def test_get_territory_combined_list_filtered(self):
         for search_term in ("rh", "rhone", "rhône", "Rhône"):
             response = self.client.get(reverse("territory-combined-list") + f"?q={search_term}")


### PR DESCRIPTION
- Use an autouse to always mock the calls to geo.api.gouv.fr
- create initial factories for CLEF import
- remove the test on territory api with no filter as q is now mandatory